### PR TITLE
Fix MongoDB

### DIFF
--- a/src/modules/farmpi/filesystem/root/etc/systemd/system/mongod.service
+++ b/src/modules/farmpi/filesystem/root/etc/systemd/system/mongod.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Mongo DB
+After=multi-user.target
+
+[Service]
+Type=idle
+ExecStart=/root/bin/mdb/mongod --dbpath /data/db/octofarm_db --logpath /data/db/octofarm_db_log/db.log --port 27017
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/farmpi/start_chroot_script
+++ b/src/modules/farmpi/start_chroot_script
@@ -36,12 +36,18 @@ echo " - Reinstall iputils-ping"
 apt-get install --reinstall iputils-ping
 
 # MongoDB
-wget -qO - https://www.mongodb.org/static/pgp/server-$FARMPI_MONGODB_VERSION.asc | sudo apt-key add -
-echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/`cat /etc/os-release | grep "^ID=" | cut -d "=" -f2` `cat /etc/os-release | grep "^VERSION_CODENAME=" | cut -d "=" -f2`/mongodb-org/$FARMPI_MONGODB_VERSION multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-$FARMPI_MONGODB_VERSION.list
-apt-get update
-apt-get install -y --force-yes mongodb-org
-systemctl enable mongod
-systemctl start mongod
+cd /root
+mkdir -p /data/db/octofarm_db
+mkdir -p /data/db/octofarm_db_log
+wget https://github.com/themattman/mongodb-raspberrypi-binaries/releases/download/r6.0.5-rpi-unofficial/mongodb.ce.pi.r6.0.5.tar.gz -P /root/mongodb.tar.gz
+mkdir tmp-mongodb
+cd tmp-mongodb
+mv ../mongodb.tar.gz .
+tar xzvf mongodb.tar.gz
+cp mongod /root/bin/mongod
+cd ..
+rm -rf tmp-mongodb
+
 
 # NodeJS
 curl -sL https://deb.nodesource.com/setup_$FARMPI_NODEJS_VERSION | bash -
@@ -149,6 +155,8 @@ else
   # let's remove the configs for system services we don't need
   rm /etc/systemd/system/gencert.service
 fi
+
+systemctl_if_exists enable mongod.service
 
 #cleanup
 apt-get clean

--- a/src/modules/farmpi/start_chroot_script
+++ b/src/modules/farmpi/start_chroot_script
@@ -39,11 +39,11 @@ apt-get install --reinstall iputils-ping
 cd /root
 mkdir -p /data/db/octofarm_db
 mkdir -p /data/db/octofarm_db_log
-wget https://github.com/themattman/mongodb-raspberrypi-binaries/releases/download/r6.0.5-rpi-unofficial/mongodb.ce.pi.r6.0.5.tar.gz -P /root/mongodb.tar.gz
+wget https://github.com/themattman/mongodb-raspberrypi-binaries/releases/download/r6.0.5-rpi-unofficial/mongodb.ce.pi.r6.0.5.tar.gz
 mkdir tmp-mongodb
 cd tmp-mongodb
-mv ../mongodb.tar.gz .
-tar xzvf mongodb.tar.gz
+mv ../mongodb.ce.pi.r6.0.5.tar.gz .
+tar xzvf mongodb.ce.pi.r6.0.5.tar.gz
 cp mongod /root/bin/mongod
 cd ..
 rm -rf tmp-mongodb


### PR DESCRIPTION
Install working MongoDB binaries.

## Description
Currently the MongoDB 4.4 package no longer runs on the RPIs. Instead we get new binaries from https://github.com/themattman/mongodb-raspberrypi-binaries 

## Related Issue
#53 

## Motivation and Context
Well I decided to install a nightly build so I get the latest version of Octofarm. I install it but I then come to find MongoDB is broken. 

## How Has This Been Tested?
I have built this on Ubuntu and has been tested under a Raspberry PI 4.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
